### PR TITLE
fixes line breaks for code blocks

### DIFF
--- a/static/css/bootstrap-theme.css
+++ b/static/css/bootstrap-theme.css
@@ -1658,7 +1658,12 @@ body.blog .author-detail ul li a i {
 
 body.get_started kbd,
 pre, code {
-	display:inline-block;
+	display: block;
+	width: auto;
+	overflow: auto;
+	-webkit-overflow-scrolling: touch;
+	white-space: pre;
+	word-wrap: normal;
 	padding:10px 20px;
 	margin:10px 0;
 	color:#49d5a2;
@@ -1668,6 +1673,8 @@ pre, code {
 	background-color:#333;
 	border:none;
 }
+pre::-webkit-scrollbar{height:.5em;background:rgba(255,255,255,0.15)}
+pre::-webkit-scrollbar-thumb:horizontal{background:rgba(255,255,255,0.2); -webkit-border-radius: 4px; border-radius: 4px }
 code {
 	background-color:#efefef;
 	padding:0 5px;


### PR DESCRIPTION
see https://github.com/PyBossa/pybossa.github.com/issues/15

looks now on chrome mobile and desktop (when line to long, no word wrap anymore):
![image](https://cloud.githubusercontent.com/assets/1050582/10104035/d1c48d3a-63a7-11e5-96bb-1da8a46499d7.png)

Also tested on newest iPhone :yum: Touch works there.
![image](https://cloud.githubusercontent.com/assets/1050582/10104053/e81fd54e-63a7-11e5-9a0e-a43a434cc140.png)

Firefox does not have css for always show vertical scrollbars :-1:
![image](https://cloud.githubusercontent.com/assets/1050582/10104123/1eaba17e-63a8-11e5-9fd5-855b01ad856a.png)
